### PR TITLE
Change to use _json_data instead of _json. Resolves #3.

### DIFF
--- a/CiscoSpark.py
+++ b/CiscoSpark.py
@@ -48,7 +48,7 @@ class CiscoSparkPerson(Person):
 
     @id.setter
     def id(self, val):
-        self._spark_person._json['id'] = val
+        self._spark_person._json_data['id'] = val
 
     @property
     def emails(self):
@@ -192,7 +192,7 @@ class CiscoSparkRoom(Room):
 
     @id.setter
     def id(self, val):
-        self._spark_room._json['id'] = val
+        self._spark_room._json_data['id'] = val
 
     @property
     def title(self):


### PR DESCRIPTION
Fixes "AttributeError: 'Person' object has no attribute '_json' #3"

Reading through the source code of the `ciscosparkapi` module it seems
that at some point (I didn't dig for when) `_json` became `_json_data`.
This patch changes `CiscoSpark.py` to use the new name.